### PR TITLE
Updated cartItems parameters in line 308

### DIFF
--- a/src/controllers/CustomerController.ts
+++ b/src/controllers/CustomerController.ts
@@ -305,7 +305,7 @@ export const CreateOrder = async (req: Request, res: Response, next: NextFunctio
                 if(food._id == _id){
                     vendorId = food.vendorId;
                     netAmount += (food.price * unit);
-                    cartItems.push({ food, unit})
+                    cartItems.push({ food._id, unit})
                 }
             })
         })


### PR DESCRIPTION
cart items first value can only be objectId as defined in the order schema itself, if we push {food,unit}, mongoose is throwing error as food is not orderId rather object itself.